### PR TITLE
Translated (synced) pages with Wagtail-Localize cannot be deleted

### DIFF
--- a/wagtail_qrcode/wagtail_hooks.py
+++ b/wagtail_qrcode/wagtail_hooks.py
@@ -55,7 +55,7 @@ def send_qr_code_email(page, email=None, subject=None, body=None):
 
 @hooks.register("after_delete_page")
 def delete_document(request, page):
-    if is_qrcode_instance(page):
+    if is_qrcode_instance(page) and page.qr_code_eps:
         doc = get_document_model().objects.filter(id=page.qr_code_eps.id)
         if doc:
             doc.delete()


### PR DESCRIPTION
Hello

We use wagtail-localize [1] plugin for the internalization of our website. The original pages with QR-Codes can be deleted correctly, but the synced translated pages cause errors, since they don't have any automatically generated QR-Codes.

I added an additional check before deleting the document, if the EPS object really exists. 

Best regards
Cahit

[1] https://github.com/wagtail/wagtail-localize